### PR TITLE
Use `private(set)` instead of private properties

### DIFF
--- a/Module/Deprecated/HTTP/HTTPRequest.swift
+++ b/Module/Deprecated/HTTP/HTTPRequest.swift
@@ -7,8 +7,5 @@ public protocol HTTPRequestType {
 public struct HTTPRequest<T>: HTTPRequestType {
 	public typealias Body = T
 	
-	private var _body: Body?
-	public var body: Body? {
-        return _body
-	}
+	public private(set) var body: Body?
 }

--- a/Module/Streams/PullStream.swift
+++ b/Module/Streams/PullStream.swift
@@ -20,12 +20,9 @@ public class PullableStream<T: StreamBuffer>: Pullable {
         return pull()
     }
     
-    private var _isAtEnd = false
-    public var isAtEnd: Bool {
-        return _isAtEnd
-    }
+    public private(set) var isAtEnd: Bool = false
     public func end() {
-        _isAtEnd = true
+        isAtEnd = true
     }
 }
 

--- a/Module/Streams/PushStream.swift
+++ b/Module/Streams/PushStream.swift
@@ -20,12 +20,9 @@ public class PushStream<T: StreamBuffer>: Pushable, Writeable, BufferedAppendabl
         self.buffer.appendContentsOf(newElements)
     }
     
-    private var _isAtEnd = false
-    public var isAtEnd: Bool {
-        return _isAtEnd
-    }
+    public private(set) var isAtEnd: Bool = false
     public func end() {
-        _isAtEnd = true
+        isAtEnd = true
 		
 		let result = Result.Success(Sequence())
 		for handler in handlers {


### PR DESCRIPTION
I only recently learned that Swift supports tighter access restrictions for setters, making the dance of public readonly + private readwrite much simpler. Not sure when it snuck in to the language, but [it’s there](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/AccessControl.html#//apple_ref/doc/uid/TP40014097-CH41-ID18).
